### PR TITLE
Only produce Python modules for the latest minor version for a given major version.

### DIFF
--- a/pipeline/src/module_template.py.txt
+++ b/pipeline/src/module_template.py.txt
@@ -18,6 +18,7 @@ class {{ class_name }}({{ base_class }}):
     context = {
         "vocab": "https://openminds.ebrains.eu/vocab/"
     }
+    schema_version = "{{ schema_version }}"
 
     properties = [
         {% for property in properties -%}


### PR DESCRIPTION
i.e. instead of `openminds.v3_1`, `openminds.v3_0` we only generate `openminds.v3`, which uses the v3.1 schemas.

Also: put full schema version as an attribute of each Node class