### PR TITLE
Remove @type from links (fixes #9)

### DIFF
--- a/pipeline/src/base.py
+++ b/pipeline/src/base.py
@@ -14,6 +14,10 @@ from .registry import Registry
 
 
 class Node(metaclass=Registry):
+    """
+    Base class for a metadata node
+    """
+
     @property
     def uuid(self):
         if self.id is not None:
@@ -29,7 +33,7 @@ class Node(metaclass=Registry):
 
     def to_jsonld(self, include_empty_properties=True, embed_linked_nodes=True, with_context=True):
         """
-        docstring goes here
+        Return a represention of this metadata node as a dictionary that can be directly serialized to JSON-LD.
         """
 
         def value_to_jsonld(value):
@@ -77,7 +81,7 @@ class Node(metaclass=Registry):
     @classmethod
     def from_jsonld(cls, data):
         """
-        docstring goes here
+        Create a Python object representing a metadata node from a JSON-LD-compatible dictionary
         """
         data_copy = data.copy()
         context = data_copy.pop("@context", None)
@@ -141,7 +145,7 @@ class Node(metaclass=Registry):
 
 class LinkedMetadata(Node):
     """
-    docstring goes here
+    A Python representation of a metadata node that should have a unique identifier.
     """
 
     def __init__(self, id=None, **properties):
@@ -151,7 +155,7 @@ class LinkedMetadata(Node):
 
     def save(self, file_path, indent=2):
         """
-        docstring goes here
+        Save this object to a file in JSON-LD format
         """
         with open(file_path, "w") as output_file:
             json.dump(self.to_jsonld(), output_file, indent=indent)
@@ -159,7 +163,7 @@ class LinkedMetadata(Node):
     @classmethod
     def load(cls, file_path):
         """
-        docstring goes here
+        Create a Python object representing a metadata node from a JSON-LD file
         """
         with open(file_path, "r") as input_file:
             data = json.load(input_file)
@@ -168,7 +172,8 @@ class LinkedMetadata(Node):
 
 class EmbeddedMetadata(Node):
     """
-    docstring goes here
+    A Python representation of a metadata node that should only be embedded within another node,
+    and should not have a unique identifier.
     """
 
     def __init__(self, **properties):
@@ -177,6 +182,10 @@ class EmbeddedMetadata(Node):
 
 
 class IRI:
+    """
+    Representation of an Internationalized Resource Identifier
+    """
+
     def __init__(self, value: Union[str, IRI]):
         if isinstance(value, IRI):
             iri = value.value

--- a/pipeline/src/base.py
+++ b/pipeline/src/base.py
@@ -142,7 +142,7 @@ class Node(metaclass=Registry):
                 _links.extend(value.links)
         return _links
 
-    def resolve_links(self, node_lookup):
+    def _resolve_links(self, node_lookup):
         """Replace `Link` attributes with typed Nodes where possible"""
         for property in self.__class__.properties:
             value = getattr(self, property.name)

--- a/pipeline/src/base.py
+++ b/pipeline/src/base.py
@@ -47,7 +47,7 @@ class Node(metaclass=Registry):
                 else:
                     if hasattr(value, "id") and value.id is None:
                         raise ValueError("Exporting as a stand-alone JSON-LD document requires @id to be defined.")
-                    item = {"@id": value.id, "@type": value.type_}
+                    item = {"@id": value.id}
             elif isinstance(value, EmbeddedMetadata):
                 item = value.to_jsonld(
                     with_context=False,
@@ -142,6 +142,14 @@ class Node(metaclass=Registry):
                 _links.extend(value.links)
         return _links
 
+    def resolve_links(self, node_lookup):
+        """Replace `Link` attributes with typed Nodes where possible"""
+        for property in self.__class__.properties:
+            value = getattr(self, property.name)
+            if isinstance(value, Link):
+                resolved_value = node_lookup[value.identifier]
+                setattr(self, property.name, resolved_value)
+
 
 class LinkedMetadata(Node):
     """
@@ -181,9 +189,16 @@ class EmbeddedMetadata(Node):
             setattr(self, name, value)
 
 
+class Link:
+    """Representation of a metadata node for which only the identifier is currently known."""
+
+    def __init__(self, identifier):
+        self.identifier = identifier
+
+
 class IRI:
     """
-    Representation of an Internationalized Resource Identifier
+    Representation of an International Resource Identifier
     """
 
     def __init__(self, value: Union[str, IRI]):

--- a/pipeline/src/collection.py
+++ b/pipeline/src/collection.py
@@ -167,12 +167,12 @@ class Collection:
                         raise ValueError("Local nodes must have @type specified")
                     node = Link(data["@id"])
                 self.add(node)
-        self.resolve_links()
+        self._resolve_links()
 
-    def resolve_links(self):
+    def _resolve_links(self):
         """Replace `Link` attributes with typed Nodes where possible"""
         for node in self.nodes.values():
-            node.resolve_links(self.nodes)
+            node._resolve_links(self.nodes)
 
     def validate(self):
         """

--- a/pipeline/src/properties.py
+++ b/pipeline/src/properties.py
@@ -7,7 +7,7 @@ Representations of metadata fields/properties
 from datetime import datetime, date
 from collections import defaultdict
 from .registry import lookup
-from .base import Node, IRI
+from .base import Node, IRI, Link
 
 
 class Property:
@@ -145,7 +145,7 @@ class Property:
                         if cls.type_ == item["@type"]:
                             return cls.from_jsonld(item)
                 else:
-                    raise Exception("missing @type")
+                    return Link(item["@id"])
             else:
                 raise NotImplementedError()
 

--- a/pipeline/tests/test_regressions.py
+++ b/pipeline/tests/test_regressions.py
@@ -98,15 +98,13 @@ def test_issue0007():
             {
                 "@type": "https://openminds.ebrains.eu/core/Affiliation",
                 "memberOf": {
-                    "@id": "_:002",
-                    "@type": "https://openminds.ebrains.eu/core/Organization",
+                    "@id": "_:002"
                 },
             },
             {
                 "@type": "https://openminds.ebrains.eu/core/Affiliation",
                 "memberOf": {
-                    "@id": "_:003",
-                    "@type": "https://openminds.ebrains.eu/core/Organization",
+                    "@id": "_:003"
                 },
             },
         ],
@@ -130,15 +128,13 @@ def test_issue0007():
                     {
                         "@type": "https://openminds.ebrains.eu/core/Affiliation",
                         "memberOf": {
-                            "@id": "_:002",
-                            "@type": "https://openminds.ebrains.eu/core/Organization",
+                            "@id": "_:002"
                         },
                     },
                     {
                         "@type": "https://openminds.ebrains.eu/core/Affiliation",
                         "memberOf": {
-                            "@id": "_:003",
-                            "@type": "https://openminds.ebrains.eu/core/Organization",
+                            "@id": "_:003"
                         },
                     },
                 ],
@@ -182,8 +178,7 @@ def test_issue0008():
                 "@type": "https://openminds.ebrains.eu/core/Affiliation",
                 "endDate": "2023-09-30",
                 "memberOf": {
-                    "@id": "_:001",
-                    "@type": "https://openminds.ebrains.eu/core/Organization",
+                    "@id": "_:001"
                 },
             }
         ],


### PR DESCRIPTION
JSON-LD files are now read as follows:
- when a property value just contains `@id` we represent it as a Link object
- once all nodes have been read, we can lookup the node that corresponds to each link, and replace the Link objects with the actual Nodes. 