### PR TITLE
Allow a datetime string to be provided for a property with type "date"

### DIFF
--- a/pipeline/src/properties.py
+++ b/pipeline/src/properties.py
@@ -202,7 +202,15 @@ class Property:
             elif datetime in self.types:
                 return datetime.fromisoformat(item)
             elif date in self.types:
-                return date.fromisoformat(item)
+                try:
+                    return date.fromisoformat(item)
+                except ValueError as err:
+                    # if a datetime string has been provided
+                    # take the date part.
+                    try:
+                        return datetime.fromisoformat(item).date()
+                    except ValueError:
+                        raise err
             elif all(issubclass(t, Node) for t in self.types):
                 # use data["@type"] to figure out class to use
                 if "@type" in item:


### PR DESCRIPTION
The aim of this PR is to be more forgiving when handling JSON-LD documents generated by other tools.

Specifically, if the document contains a datetime string, such as "2024-02-07T00:00:00" where openMINDS expects a date (like "2024-02-07"), we should accept that.

A stricter version of this would be to only accept strings where the hour-minute-second fields are all zero, but the current implementation just throws away the time information.