### PR TITLE
Accept `@type` as a list containing a single IRI

### DIFF
--- a/pipeline/src/base.py
+++ b/pipeline/src/base.py
@@ -119,6 +119,8 @@ class Node(metaclass=Registry):
         data_copy = data.copy()
         context = data_copy.pop("@context", None)
         type_ = data_copy.pop("@type")
+        if isinstance(type_, list) and len(type_) == 1:
+            type_ = type_[0]
         if type_ and type_ != cls.type_:
             raise TypeError(f"Mismatched types. Data has '{type_}' but trying to create '{cls.type_}'")
         deserialized_data = {}

--- a/pipeline/src/properties.py
+++ b/pipeline/src/properties.py
@@ -206,8 +206,12 @@ class Property:
             elif all(issubclass(t, Node) for t in self.types):
                 # use data["@type"] to figure out class to use
                 if "@type" in item:
+                    if isinstance(item["@type"], list) and len(item["@type"]) == 1:
+                        item_type = item["@type"][0]
+                    else:
+                        item_type = item["@type"]
                     for cls in self.types:
-                        if cls.type_ == item["@type"]:
+                        if cls.type_ == item_type:
                             if set(item.keys()) == link_keys:
                                 # if we only have @id and @type, it's a Link
                                 return Link(item["@id"], allowed_types=[cls])
@@ -215,8 +219,8 @@ class Property:
                                 # otherwise it's a Node
                                 return cls.from_jsonld(item)
                     raise TypeError(
-                        f"Mismatched types. Data has '{item['@type']}' "
-                        f"but property only allows {[cls.type_ for cls in self.types]}"
+                        f"Mismatched types. Data has '{item_type}' "
+                        f"but property only allows one of {[cls.type_ for cls in self.types]}"
                     )
                 else:
                     return Link(item["@id"], allowed_types=self.types)


### PR DESCRIPTION
i.e., accept documents with 
```
"@type": ["https://openminds.om-i.org/types/Person"]
```
instead of 
```
"@type": "https://openminds.om-i.org/types/Person"
```

We still always generate the second form.

This change makes it easier to ingest JSON-LD documents coming from tools like the EBRAINS Knowledge Graph.