### PR TITLE
Allow the user to specify which openMINDS version should be used by `Collection.load()`

### DIFF
--- a/pipeline/src/collection.py
+++ b/pipeline/src/collection.py
@@ -11,6 +11,9 @@ from .registry import lookup_type
 from .base import Link
 
 
+DEFAULT_VERSION = "v4"
+
+
 class Collection:
     """
     A collection of metadata nodes that can be saved to
@@ -141,7 +144,7 @@ class Collection:
                     output_paths.append(file_path)
         return output_paths
 
-    def load(self, *paths):
+    def load(self, *paths, version=DEFAULT_VERSION):
         """
         Load openMINDS metadata from one or more JSON-LD files.
 
@@ -152,6 +155,9 @@ class Collection:
         (but without descending into subdirectories)
 
         2) one or more JSON-LD files, which will all be loaded.
+
+        By default, openMINDS v4 will be used.
+        If the JSON-LD files use a different openMINDS version, specify it with the `version` argument.
         """
         if len(paths) == 1 and os.path.isdir(paths[0]):
             data_dir = paths[0]
@@ -168,10 +174,6 @@ class Collection:
             with open(path, "r") as fp:
                 data = json.load(fp)
             if "@graph" in data:
-                if data["@context"]["@vocab"].startswith("https://openminds.ebrains.eu/"):
-                    version = "v3"
-                else:
-                    version = "latest"
                 for item in data["@graph"]:
                     if "@type" in item:
                         cls = lookup_type(item["@type"], version=version)
@@ -245,4 +247,3 @@ class Collection:
                     newly_sorted.append(node_id)
             unsorted -= set(newly_sorted)
         return [self.nodes[node_id] for node_id in sorted]
-        

--- a/pipeline/tests/test_regressions.py
+++ b/pipeline/tests/test_regressions.py
@@ -2,7 +2,7 @@ from datetime import date
 import json
 import os
 from openminds import Collection, IRI
-from openminds.latest import core as omcore
+from openminds.v4 import core as omcore
 from utils import build_fake_node
 
 
@@ -261,12 +261,12 @@ def test_issue0073():
     # Infinite recursion in validate()
     ds1 = omcore.DatasetVersion(
         short_name="ds1",
-        is_variant_of=None
+        is_alternative_version_of=None
     )
     ds2 = omcore.DatasetVersion(
         short_name="ds2",
-        is_variant_of=ds1
+        is_alternative_version_of=ds1
     )
-    ds1.is_variant_of = ds2
+    ds1.is_alternative_version_of = ds2
 
     failures = ds1.validate()


### PR DESCRIPTION
By default, uses the most recent release.

This is an alternative to #75. 

The disadvantage of the approach in this PR is that the user needs to know which version of openMINDS was used to create the loaded file(s), which is fine if they created the files themselves, but a problem if someone else created them (e.g., a curator handling files generated by a data provider).

The advantages of this approach are (i) it avoids filling JSON-LD files with a lot of "schema:schemaVersion" entries, and (ii) it ensures all nodes are read with the same schema version. (The approach in #75 in theory opens the door to having a graph combining different openMINDS versions, which we probably don't want to do).
 