### PR TITLE
Replace the "black" formatter with "ruff"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Run build
+    - name: Install requirements
       run: |
         pip install -r requirements.txt
+
+    - name: Run build
+      run: |
         python build.py
 
     - name: Test built package

--- a/pipeline/src/pyproject_template.toml.txt
+++ b/pipeline/src/pyproject_template.toml.txt
@@ -34,7 +34,7 @@ dev = [
     "setuptools",
     "wheel",
     "sphinx",
-    "black",
+    "ruff",
     "twine"
 ]
 
@@ -51,5 +51,5 @@ include = ["openminds*"]
  ]
  build-backend = "setuptools.build_meta"
 
-[tool.black]
+[tool.ruff]
 line-length = 119

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 gitpython
 jinja2
-black
+ruff


### PR DESCRIPTION
 https://docs.astral.sh/ruff

Formatting the generated code is the slowest part of the build by far. Ruff seems to be much faster than black.